### PR TITLE
fix: resolve theme-customizer missing dependencies and layout-grid JSX

### DIFF
--- a/components/animate-ui/icons/brush-cleaning.tsx
+++ b/components/animate-ui/icons/brush-cleaning.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "motion/react";
+import { cn } from "@/lib/utils";
+
+interface BrushCleaningProps extends React.SVGAttributes<SVGSVGElement> {
+  size?: number;
+  animateOnHover?: boolean;
+}
+
+/**
+ * BrushCleaning — an animated brush icon.
+ * Based on the animate-ui library's icon pattern. Uses motion/react to
+ * animate a gentle sweep on hover when `animateOnHover` is true.
+ */
+export function BrushCleaning({
+  size = 24,
+  animateOnHover = false,
+  className,
+  ...props
+}: BrushCleaningProps) {
+  const [hovered, setHovered] = React.useState(false);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("lucide lucide-brush-cleaning", className)}
+      onMouseEnter={() => animateOnHover && setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      {...(props as React.ComponentProps<typeof motion.svg>)}
+    >
+      {/* Brush handle */}
+      <motion.path
+        d="m16 22-1-4"
+        animate={hovered ? { rotate: [0, -6, 6, 0] } : { rotate: 0 }}
+        transition={{ duration: 0.5, ease: "easeInOut" }}
+        style={{ originX: "16px", originY: "22px" }}
+      />
+      {/* Brush head */}
+      <motion.path
+        d="M19 13.99a1 1 0 0 0 1-1V12a2 2 0 0 0-2-2h-3a1 1 0 0 1-1-1V4a2 2 0 0 0-4 0v5a1 1 0 0 1-1 1H6a2 2 0 0 0-2 2v.99a1 1 0 0 0 1 1"
+        animate={hovered ? { y: [0, -1, 0] } : { y: 0 }}
+        transition={{ duration: 0.4, ease: "easeInOut" }}
+      />
+      {/* Bristle lines */}
+      <motion.path
+        d="M5 14h14l1.973 6.767A1 1 0 0 1 20 22H4a1 1 0 0 1-.973-1.233z"
+        animate={hovered ? { scale: [1, 1.02, 1] } : { scale: 1 }}
+        transition={{ duration: 0.4, ease: "easeInOut" }}
+        style={{ originX: "12px", originY: "18px" }}
+      />
+    </motion.svg>
+  );
+}

--- a/components/ui/theme-customizer.tsx
+++ b/components/ui/theme-customizer.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "next-themes"
 import * as React from "react"
 import { BrushCleaning } from "@/components/animate-ui/icons/brush-cleaning"
 import { ThemeToggle } from "@/components/ui/theme-toggle"
-import { useClickOutside } from "@/hooks/use-click-outside"
+import { useOutsideClick } from "@/hooks/use-outside-click"
 import { cn } from "@/lib/utils"
 
 const colors = [
@@ -50,7 +50,7 @@ export function ThemeCustomizerPill({
   const [showColors, setShowColors] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
 
-  useClickOutside(containerRef, () => {
+  useOutsideClick(containerRef, () => {
     setShowColors(false)
   })
 
@@ -393,7 +393,7 @@ export function ThemeCustomizerToolbar({ className }: { className?: string }) {
   const [isOpen, setIsOpen] = React.useState(false)
   const containerRef = React.useRef<HTMLDivElement>(null)
 
-  useClickOutside(containerRef, () => {
+  useOutsideClick(containerRef, () => {
     setIsOpen(false)
   })
 

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size?: number;
+}
+
+/**
+ * ThemeToggle — a simple button that cycles between light and dark mode.
+ * Uses next-themes for theme state. Shows a sun icon in dark mode and a
+ * moon icon in light mode (tap to switch).
+ */
+export function ThemeToggle({
+  size = 20,
+  className,
+  ...props
+}: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Render a placeholder until mounted to avoid hydration mismatch
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        aria-label="Toggle theme"
+        className={cn(
+          "inline-flex items-center justify-center transition-colors",
+          className,
+        )}
+        {...props}
+      >
+        <Sun size={size} />
+      </button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      type="button"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className={cn(
+        "inline-flex items-center justify-center transition-colors hover:bg-accent cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      {isDark ? <Sun size={size} /> : <Moon size={size} />}
+    </button>
+  );
+}

--- a/hooks/use-outside-click.tsx
+++ b/hooks/use-outside-click.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 
 export const useOutsideClick = (
-  ref: React.RefObject<HTMLDivElement>,
-  callback: Function
+  ref: React.RefObject<HTMLDivElement | null>,
+  callback: (event: MouseEvent | TouchEvent) => void
 ) => {
   useEffect(() => {
     const listener = (event: any) => {


### PR DESCRIPTION
Create the three missing pieces the theme-customizer component needed:
- components/animate-ui/icons/brush-cleaning.tsx: animated brush icon with motion/react, supports animateOnHover prop
- components/ui/theme-toggle.tsx: next-themes-based light/dark toggle button

Fix import path mismatch: theme-customizer was importing useClickOutside from @/hooks/use-click-outside, but the existing hook is useOutsideClick from @/hooks/use-outside-click.

Update useOutsideClick ref signature to accept RefObject<T | null> for React 19 compatibility. This also resolves the two expandable-card-demo type errors as a side effect.

Layout-grid JSX.Element → React.JSX.Element for React 19 namespace change was fixed earlier in this session.

